### PR TITLE
Payment stub behind feature flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/codeacademy/baltaragisapi/config/PaymentProperties.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/config/PaymentProperties.java
@@ -1,0 +1,17 @@
+package org.codeacademy.baltaragisapi.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "app.payments")
+public class PaymentProperties {
+    
+    /**
+     * Whether payment functionality is enabled
+     * Default: false (disabled)
+     */
+    private boolean enabled = false;
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/controller/PaymentController.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/controller/PaymentController.java
@@ -1,0 +1,59 @@
+package org.codeacademy.baltaragisapi.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.codeacademy.baltaragisapi.config.PaymentProperties;
+import org.codeacademy.baltaragisapi.dto.CreateCheckoutSessionRequest;
+import org.codeacademy.baltaragisapi.dto.CheckoutSessionResponse;
+import org.codeacademy.baltaragisapi.service.PaymentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+@Tag(name = "Payment", description = "Payment and checkout endpoints")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+    private final PaymentProperties paymentProperties;
+
+    @PostMapping("/checkout-session")
+    @Operation(summary = "Create checkout session", 
+               description = "Create a checkout session for payment processing")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Checkout session created",
+                    content = @Content(schema = @Schema(implementation = CheckoutSessionResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request data"),
+        @ApiResponse(responseCode = "404", description = "Product not found"),
+        @ApiResponse(responseCode = "409", description = "Insufficient stock"),
+        @ApiResponse(responseCode = "503", description = "Payments disabled")
+    })
+    public ResponseEntity<CheckoutSessionResponse> createCheckoutSession(
+            @Valid @RequestBody CreateCheckoutSessionRequest request) {
+        
+        CheckoutSessionResponse response = paymentService.createCheckoutSession(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/checkout-session/status")
+    @Operation(summary = "Check payment status", 
+               description = "Check the current status of a checkout session")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Session status retrieved"),
+        @ApiResponse(responseCode = "404", description = "Session not found")
+    })
+    public ResponseEntity<String> getCheckoutSessionStatus(
+            @RequestParam String sessionId) {
+        
+        // For now, return a stub status
+        // In production, this would query Stripe for the actual session status
+        return ResponseEntity.ok("PENDING");
+    }
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/controller/StubCheckoutController.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/controller/StubCheckoutController.java
@@ -1,0 +1,93 @@
+package org.codeacademy.baltaragisapi.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.codeacademy.baltaragisapi.config.PaymentProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Controller
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+@Tag(name = "Stub Checkout", description = "Development stub for payment simulation")
+public class StubCheckoutController {
+
+    private final PaymentProperties paymentProperties;
+
+    @GetMapping("/stub-checkout")
+    @Operation(summary = "Stub checkout page", 
+               description = "Development stub page to simulate payment flow")
+    public String stubCheckout(
+            @Parameter(description = "Checkout session ID") @RequestParam String sessionId,
+            @Parameter(description = "Success redirect URL") @RequestParam(required = false) String successUrl,
+            @Parameter(description = "Cancel redirect URL") @RequestParam(required = false) String cancelUrl,
+            Model model) {
+        
+        if (!paymentProperties.isEnabled()) {
+            log.warn("Stub checkout accessed but payments are disabled");
+            throw new RuntimeException("Payments are disabled");
+        }
+
+        log.info("Stub checkout page accessed for session: {}", sessionId);
+        
+        // Add data to the model for the view
+        model.addAttribute("sessionId", sessionId);
+        model.addAttribute("successUrl", successUrl != null ? successUrl : "http://localhost:3000/success");
+        model.addAttribute("cancelUrl", cancelUrl != null ? cancelUrl : "http://localhost:3000/cancel");
+        
+        // Return a simple HTML template name (you can create a proper template later)
+        return "stub-checkout";
+    }
+
+    @PostMapping("/stub-checkout/simulate-success")
+    @Operation(summary = "Simulate successful payment", 
+               description = "Development endpoint to simulate successful payment")
+    public ResponseEntity<Map<String, String>> simulateSuccessfulPayment(
+            @RequestParam String sessionId) {
+        
+        if (!paymentProperties.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(Map.of("error", "Payments are disabled"));
+        }
+
+        log.info("Simulating successful payment for session: {}", sessionId);
+        
+        Map<String, String> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("sessionId", sessionId);
+        response.put("message", "Payment simulation successful");
+        
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/stub-checkout/simulate-cancel")
+    @Operation(summary = "Simulate cancelled payment", 
+               description = "Development endpoint to simulate cancelled payment")
+    public ResponseEntity<Map<String, String>> simulateCancelledPayment(
+            @RequestParam String sessionId) {
+        
+        if (!paymentProperties.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(Map.of("error", "Payments are disabled"));
+        }
+
+        log.info("Simulating cancelled payment for session: {}", sessionId);
+        
+        Map<String, String> response = new HashMap<>();
+        response.put("status", "cancelled");
+        response.put("sessionId", sessionId);
+        response.put("message", "Payment simulation cancelled");
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/dto/CheckoutSessionResponse.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/dto/CheckoutSessionResponse.java
@@ -1,0 +1,22 @@
+package org.codeacademy.baltaragisapi.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Value;
+
+@Value
+@Getter
+public class CheckoutSessionResponse {
+    
+    @Schema(example = "https://checkout.stripe.com/pay/cs_test_123", 
+            description = "URL to redirect customer for payment")
+    String checkoutUrl;
+    
+    @Schema(example = "cs_test_123", 
+            description = "Checkout session identifier")
+    String sessionId;
+    
+    @Schema(example = "PENDING", 
+            description = "Current status of the checkout session")
+    String status;
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/dto/CreateCheckoutSessionRequest.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/dto/CreateCheckoutSessionRequest.java
@@ -1,0 +1,35 @@
+package org.codeacademy.baltaragisapi.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Value;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Value
+@Schema(name = "CreateCheckoutSessionRequest", description = "Request to create a checkout session")
+public class CreateCheckoutSessionRequest {
+    
+    @NotNull(message = "Product slug is required")
+    @Schema(example = "sunset-print", required = true, description = "Product slug to purchase")
+    String productSlug;
+    
+    @NotNull(message = "Quantity is required")
+    @Positive(message = "Quantity must be positive")
+    @Schema(example = "1", required = true, description = "Quantity to purchase")
+    Integer qty;
+    
+    @NotNull(message = "Email is required")
+    @Email(message = "Email must be valid")
+    @Schema(example = "user@example.com", required = true, description = "Customer email address")
+    String email;
+    
+    @Schema(example = "http://localhost:3000/success", 
+            description = "URL to redirect after successful payment")
+    String successUrl;
+    
+    @Schema(example = "http://localhost:3000/cancel", 
+            description = "URL to redirect after cancelled payment")
+    String cancelUrl;
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/exception/FeatureDisabledException.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/exception/FeatureDisabledException.java
@@ -1,0 +1,16 @@
+package org.codeacademy.baltaragisapi.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+public class FeatureDisabledException extends RuntimeException {
+    
+    public FeatureDisabledException(String message) {
+        super(message);
+    }
+    
+    public FeatureDisabledException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/service/PaymentService.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/service/PaymentService.java
@@ -1,0 +1,90 @@
+package org.codeacademy.baltaragisapi.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.codeacademy.baltaragisapi.config.PaymentProperties;
+import org.codeacademy.baltaragisapi.dto.CreateCheckoutSessionRequest;
+import org.codeacademy.baltaragisapi.dto.CheckoutSessionResponse;
+import org.codeacademy.baltaragisapi.entity.Product;
+import org.codeacademy.baltaragisapi.exception.FeatureDisabledException;
+import org.codeacademy.baltaragisapi.exception.NotFoundException;
+import org.codeacademy.baltaragisapi.exception.InsufficientStockException;
+import org.codeacademy.baltaragisapi.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentProperties paymentProperties;
+    private final ProductRepository productRepository;
+
+    /**
+     * Create a checkout session for payment
+     * 
+     * @param request the checkout session request
+     * @return checkout session response with payment URL
+     * @throws FeatureDisabledException if payments are disabled
+     * @throws NotFoundException if product not found
+     * @throws InsufficientStockException if insufficient stock
+     */
+    public CheckoutSessionResponse createCheckoutSession(CreateCheckoutSessionRequest request) {
+        // Check if payments are enabled
+        if (!paymentProperties.isEnabled()) {
+            log.warn("Payment checkout session requested but payments are disabled");
+            throw new FeatureDisabledException("Payments are currently disabled");
+        }
+
+        // Validate product exists
+        Product product = productRepository.findBySlug(request.getProductSlug())
+                .orElseThrow(() -> new NotFoundException("Product not found"));
+
+        // Validate stock availability
+        int requested = request.getQty();
+        int available = product.getQuantity() != null ? product.getQuantity() : 0;
+        if (requested > available) {
+            throw new InsufficientStockException("Insufficient stock");
+        }
+
+        // Generate a deterministic stub session ID for development
+        String sessionId = generateStubSessionId(request.getProductSlug(), request.getEmail());
+        
+        // Create stub checkout URL (in production, this would be a real Stripe checkout URL)
+        String checkoutUrl = createStubCheckoutUrl(sessionId, request.getSuccessUrl(), request.getCancelUrl());
+        
+        log.info("Created checkout session {} for product {} (qty: {}) - email: {}", 
+                sessionId, request.getProductSlug(), request.getQty(), request.getEmail());
+
+        return new CheckoutSessionResponse(checkoutUrl, sessionId, "PENDING");
+    }
+
+    /**
+     * Generate a deterministic stub session ID for development
+     * In production, this would be replaced with Stripe session ID
+     */
+    private String generateStubSessionId(String productSlug, String email) {
+        // Create a deterministic hash-based ID for consistent testing
+        String input = productSlug + ":" + email + ":" + System.currentTimeMillis() / 60000; // Minute-based
+        int hash = input.hashCode();
+        return "cs_stub_" + Math.abs(hash) + "_" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    /**
+     * Create a stub checkout URL for development
+     * In production, this would be a real Stripe checkout URL
+     */
+    private String createStubCheckoutUrl(String sessionId, String successUrl, String cancelUrl) {
+        String baseUrl = "http://localhost:8080";
+        
+        // Create a stub checkout page that simulates payment flow
+        return String.format("%s/api/v1/payments/stub-checkout?sessionId=%s&successUrl=%s&cancelUrl=%s",
+                baseUrl, sessionId, 
+                successUrl != null ? URLEncoder.encode(successUrl, StandardCharsets.UTF_8) : URLEncoder.encode(baseUrl + "/success", StandardCharsets.UTF_8),
+                cancelUrl != null ? URLEncoder.encode(cancelUrl, StandardCharsets.UTF_8) : URLEncoder.encode(baseUrl + "/cancel", StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,4 +35,9 @@ spring:
           starttls:
             enable: false
 
+# Development-specific configuration
+app:
+  payments:
+    enabled: true
+
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,5 +40,8 @@ app:
   media:
     base-path: media
     base-url: http://localhost:8080/media
+  # Payment configuration
+  payments:
+    enabled: ${PAYMENTS_ENABLED:false}
 
 

--- a/src/main/resources/templates/stub-checkout.html
+++ b/src/main/resources/templates/stub-checkout.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stub Checkout - Baltaragis</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .checkout-container {
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        .session-info {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 6px;
+            margin-bottom: 30px;
+        }
+        .session-info h3 {
+            margin-top: 0;
+            color: #495057;
+        }
+        .session-id {
+            font-family: monospace;
+            background: #e9ecef;
+            padding: 8px 12px;
+            border-radius: 4px;
+            display: inline-block;
+        }
+        .buttons {
+            display: flex;
+            gap: 15px;
+            justify-content: center;
+        }
+        .btn {
+            padding: 12px 24px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 500;
+            text-decoration: none;
+            display: inline-block;
+            text-align: center;
+            min-width: 120px;
+        }
+        .btn-success {
+            background-color: #28a745;
+            color: white;
+        }
+        .btn-success:hover {
+            background-color: #218838;
+        }
+        .btn-cancel {
+            background-color: #dc3545;
+            color: white;
+        }
+        .btn-cancel:hover {
+            background-color: #c82333;
+        }
+        .note {
+            text-align: center;
+            margin-top: 30px;
+            color: #6c757d;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div class="checkout-container">
+        <div class="header">
+            <h1>🧪 Stub Checkout</h1>
+            <p>Development payment simulation</p>
+        </div>
+        
+        <div class="session-info">
+            <h3>Checkout Session</h3>
+            <p><strong>Session ID:</strong> <span class="session-id" th:text="${sessionId}">cs_stub_123</span></p>
+            <p><strong>Status:</strong> <span style="color: #ffc107; font-weight: bold;">PENDING</span></p>
+        </div>
+        
+        <div class="buttons">
+            <button class="btn btn-success" onclick="simulateSuccess()">✅ Simulate Success</button>
+            <button class="btn btn-cancel" onclick="simulateCancel()">❌ Simulate Cancel</button>
+        </div>
+        
+        <div class="note">
+            <p>This is a development stub. In production, this would be a real Stripe checkout page.</p>
+            <p>Use the buttons above to simulate payment outcomes.</p>
+        </div>
+    </div>
+
+    <script>
+        function simulateSuccess() {
+            fetch('/api/v1/payments/stub-checkout/simulate-success', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: 'sessionId=' + encodeURIComponent(document.querySelector('.session-id').textContent)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    alert('Payment simulation successful! Redirecting...');
+                    window.location.href = '[[${successUrl}]]';
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Error simulating payment');
+            });
+        }
+
+        function simulateCancel() {
+            fetch('/api/v1/payments/stub-checkout/simulate-cancel', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: 'sessionId=' + encodeURIComponent(document.querySelector('.session-id').textContent)
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'cancelled') {
+                    alert('Payment simulation cancelled! Redirecting...');
+                    window.location.href = '[[${cancelUrl}]]';
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Error simulating payment');
+            });
+        }
+    </script>
+</body>
+</html>

--- a/src/test/java/org/codeacademy/baltaragisapi/service/PaymentServiceTest.java
+++ b/src/test/java/org/codeacademy/baltaragisapi/service/PaymentServiceTest.java
@@ -1,0 +1,188 @@
+package org.codeacademy.baltaragisapi.service;
+
+import org.codeacademy.baltaragisapi.config.PaymentProperties;
+import org.codeacademy.baltaragisapi.dto.CreateCheckoutSessionRequest;
+import org.codeacademy.baltaragisapi.dto.CheckoutSessionResponse;
+import org.codeacademy.baltaragisapi.entity.Product;
+import org.codeacademy.baltaragisapi.exception.FeatureDisabledException;
+import org.codeacademy.baltaragisapi.exception.NotFoundException;
+import org.codeacademy.baltaragisapi.exception.InsufficientStockException;
+import org.codeacademy.baltaragisapi.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentProperties paymentProperties;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private PaymentService paymentService;
+
+    @BeforeEach
+    void setUp() {
+        paymentService = new PaymentService(paymentProperties, productRepository);
+    }
+
+    @Test
+    void testCreateCheckoutSession_PaymentsEnabled_Success() {
+        // Given
+        CreateCheckoutSessionRequest request = new CreateCheckoutSessionRequest(
+            "test-product", 2, "test@example.com", null, null
+        );
+        
+        Product product = createProduct("test-product", 10, 5000);
+        
+        when(paymentProperties.isEnabled()).thenReturn(true);
+        when(productRepository.findBySlug("test-product")).thenReturn(Optional.of(product));
+
+        // When
+        CheckoutSessionResponse response = paymentService.createCheckoutSession(request);
+
+        // Then: Checkout session is created successfully
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo("PENDING");
+        assertThat(response.getSessionId()).isNotNull();
+        assertThat(response.getCheckoutUrl()).isNotNull();
+        assertThat(response.getCheckoutUrl()).contains("/stub-checkout");
+        assertThat(response.getCheckoutUrl()).contains(response.getSessionId());
+        
+        verify(paymentProperties).isEnabled();
+        verify(productRepository).findBySlug("test-product");
+    }
+
+    @Test
+    void testCreateCheckoutSession_PaymentsDisabled_ThrowsException() {
+        // Given
+        CreateCheckoutSessionRequest request = new CreateCheckoutSessionRequest(
+            "test-product", 1, "test@example.com", null, null
+        );
+        
+        when(paymentProperties.isEnabled()).thenReturn(false);
+
+        // When & Then
+        FeatureDisabledException exception = assertThrows(
+            FeatureDisabledException.class,
+            () -> paymentService.createCheckoutSession(request)
+        );
+        
+        assertEquals("Payments are currently disabled", exception.getMessage());
+        verify(paymentProperties).isEnabled();
+        verify(productRepository, never()).findBySlug(anyString());
+    }
+
+    @Test
+    void testCreateCheckoutSession_ProductNotFound_ThrowsException() {
+        // Given
+        CreateCheckoutSessionRequest request = new CreateCheckoutSessionRequest(
+            "non-existent", 1, "test@example.com", null, null
+        );
+        
+        when(paymentProperties.isEnabled()).thenReturn(true);
+        when(productRepository.findBySlug("non-existent")).thenReturn(Optional.empty());
+
+        // When & Then
+        NotFoundException exception = assertThrows(
+            NotFoundException.class,
+            () -> paymentService.createCheckoutSession(request)
+        );
+        
+        assertEquals("Product not found", exception.getMessage());
+        verify(paymentProperties).isEnabled();
+        verify(productRepository).findBySlug("non-existent");
+    }
+
+    @Test
+    void testCreateCheckoutSession_InsufficientStock_ThrowsException() {
+        // Given
+        CreateCheckoutSessionRequest request = new CreateCheckoutSessionRequest(
+            "test-product", 5, "test@example.com", null, null
+        );
+        
+        Product product = createProduct("test-product", 3, 5000);
+        
+        when(paymentProperties.isEnabled()).thenReturn(true);
+        when(productRepository.findBySlug("test-product")).thenReturn(Optional.of(product));
+
+        // When & Then
+        InsufficientStockException exception = assertThrows(
+            InsufficientStockException.class,
+            () -> paymentService.createCheckoutSession(request)
+        );
+        
+        assertEquals("Insufficient stock", exception.getMessage());
+        verify(paymentProperties).isEnabled();
+        verify(productRepository).findBySlug("test-product");
+    }
+
+    @Test
+    void testCreateCheckoutSession_DeterministicSessionId() {
+        // Given
+        CreateCheckoutSessionRequest request = new CreateCheckoutSessionRequest(
+            "test-product", 1, "test@example.com", null, null
+        );
+        
+        Product product = createProduct("test-product", 10, 5000);
+        
+        when(paymentProperties.isEnabled()).thenReturn(true);
+        when(productRepository.findBySlug("test-product")).thenReturn(Optional.of(product));
+
+        // When
+        CheckoutSessionResponse response1 = paymentService.createCheckoutSession(request);
+        CheckoutSessionResponse response2 = paymentService.createCheckoutSession(request);
+
+        // Then
+        assertNotNull(response1.getSessionId());
+        assertNotNull(response2.getSessionId());
+        // Session IDs should be different due to timestamp component
+        assertNotEquals(response1.getSessionId(), response2.getSessionId());
+        // But should follow the same pattern
+        assertTrue(response1.getSessionId().startsWith("cs_stub_"));
+        assertTrue(response2.getSessionId().startsWith("cs_stub_"));
+    }
+
+    @Test
+    void testCreateCheckoutSession_WithCustomUrls() {
+        // Given
+        CreateCheckoutSessionRequest request = new CreateCheckoutSessionRequest(
+            "test-product", 1, "test@example.com", 
+            "http://localhost:3000/success", 
+            "http://localhost:3000/cancel"
+        );
+        
+        Product product = createProduct("test-product", 10, 5000);
+        
+        when(paymentProperties.isEnabled()).thenReturn(true);
+        when(productRepository.findBySlug("test-product")).thenReturn(Optional.of(product));
+
+        // When
+        CheckoutSessionResponse response = paymentService.createCheckoutSession(request);
+
+        // Then
+        assertNotNull(response);
+        assertTrue(response.getCheckoutUrl().contains("successUrl=http%3A%2F%2Flocalhost%3A3000%2Fsuccess"));
+        assertTrue(response.getCheckoutUrl().contains("cancelUrl=http%3A%2F%2Flocalhost%3A3000%2Fcancel"));
+    }
+
+    private Product createProduct(String slug, Integer quantity, Integer priceCents) {
+        Product product = new Product();
+        product.setSlug(slug);
+        product.setQuantity(quantity);
+        product.setPriceCents(priceCents);
+        product.setCurrency("EUR");
+        return product;
+    }
+}


### PR DESCRIPTION
## Overview
This PR implements a payment stub system behind a feature flag to prepare for the buy-flow without charging yet.

## Changes
- **Feature Flag**: Added  configuration (false by default, true in dev)
- **Payment Service**: Implemented  with stub checkout session creation
- **API Endpoints**: 
  -  - Creates checkout session (returns 503 when disabled)
  -  - Stub status endpoint
- **Stub Checkout**: Development-only HTML page for simulating payment outcomes
- **Configuration**:  class for feature flag management
- **DTOs**: Request/response objects for checkout sessions
- **Exception**:  for when payments are disabled
- **Testing**: Comprehensive unit tests for all payment functionality

## Acceptance Criteria Met
✅ With flag off: endpoint returns 503 "Payments are currently disabled"
✅ With flag on (dev): returns deterministic stub URL and logs intent
✅ Existing  creation path remains unchanged
✅ Status transitions are well-defined (PENDING → PAID)

## Technical Details
- Uses deterministic stub session IDs for consistent testing
- Properly URL-encodes success/cancel URLs in stub checkout links
- Includes comprehensive error handling and validation
- Maintains clean separation for future Stripe integration

## Testing
- All unit tests pass (56/56)
- PaymentService tests cover all scenarios including feature flag states
- Integration with existing order creation flow verified