### PR TITLE
Add missing navigation and home page translations for EN/LT locales

### DIFF
--- a/src/main/resources/db/migration/V6__add_navigation_and_home_translations.sql
+++ b/src/main/resources/db/migration/V6__add_navigation_and_home_translations.sql
@@ -1,0 +1,31 @@
+-- Add missing navigation and home page translations for both English and Lithuanian locales
+INSERT INTO translation (translation_key, locale, translation_value, updated_at) VALUES
+-- Navigation keys - English
+('nav.home', 'en-US', 'Home', CURRENT_TIMESTAMP),
+('nav.about', 'en-US', 'About', CURRENT_TIMESTAMP),
+('nav.products', 'en-US', 'Products', CURRENT_TIMESTAMP),
+
+-- Navigation keys - Lithuanian
+('nav.home', 'lt-LT', 'Pradžia', CURRENT_TIMESTAMP),
+('nav.about', 'lt-LT', 'Apie', CURRENT_TIMESTAMP),
+('nav.products', 'lt-LT', 'Darbai', CURRENT_TIMESTAMP),
+
+-- Home page keys - English
+('home.welcome', 'en-US', 'Welcome to Baltaragis', CURRENT_TIMESTAMP),
+('home.subtitle', 'en-US', 'Contemporary artist blending traditional forms with modern techniques', CURRENT_TIMESTAMP),
+('home.view_artwork', 'en-US', 'View Artwork', CURRENT_TIMESTAMP),
+('home.learn_more', 'en-US', 'Learn More', CURRENT_TIMESTAMP),
+('home.featured_works', 'en-US', 'Featured Works', CURRENT_TIMESTAMP),
+('home.featured_description', 'en-US', 'Discover our latest collection of contemporary art pieces', CURRENT_TIMESTAMP),
+('home.browse_all', 'en-US', 'Browse All Works', CURRENT_TIMESTAMP),
+('home.page_title', 'en-US', 'Home', CURRENT_TIMESTAMP),
+
+-- Home page keys - Lithuanian
+('home.welcome', 'lt-LT', 'Sveiki atvykę į Baltaragis', CURRENT_TIMESTAMP),
+('home.subtitle', 'lt-LT', 'Šiuolaikinis menininkas, derinantis tradicines formas su moderniaisiais metodais', CURRENT_TIMESTAMP),
+('home.view_artwork', 'lt-LT', 'Peržiūrėti darbus', CURRENT_TIMESTAMP),
+('home.learn_more', 'lt-LT', 'Sužinoti daugiau', CURRENT_TIMESTAMP),
+('home.featured_works', 'lt-LT', 'Išrinkti darbai', CURRENT_TIMESTAMP),
+('home.featured_description', 'lt-LT', 'Atraskite mūsų naujausią šiuolaikinio meno kūrinių kolekciją', CURRENT_TIMESTAMP),
+('home.browse_all', 'lt-LT', 'Peržiūrėti visus darbus', CURRENT_TIMESTAMP),
+('home.page_title', 'lt-LT', 'Pradžia', CURRENT_TIMESTAMP);


### PR DESCRIPTION
## Overview
This PR adds the missing translation keys that the frontend is trying to use for navigation and home page content.

## Changes
- **New Migration**: V6__add_navigation_and_home_translations.sql
- **Navigation Keys**: nav.home, nav.about, nav.products
- **Home Page Keys**: home.welcome, home.subtitle, home.view_artwork, home.learn_more, home.featured_works, home.featured_description, home.browse_all, home.page_title
- **Locale Support**: Both English (en-US) and Lithuanian (lt-LT)

## Translation Examples
- **EN**: nav.home → "Home", home.welcome → "Welcome to Baltaragis"
- **LT**: nav.home → "Pradžia", home.welcome → "Sveiki atvykę į Baltaragis"

## Impact
- Total translations increased from 21 to 32 keys
- Frontend language switching should now work without missing key warnings
- All navigation and home page content properly localized

## Testing
- Verified both EN and LT locales return the new keys
- Confirmed translation values are correct for both languages
- Migration successfully applied and tested in development environment