### PR TITLE
Rate limiting for orders & waitlist (429 on abuse)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.vladimir-bukhtoyarov</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>7.6.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/codeacademy/baltaragisapi/config/RateLimitProperties.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/config/RateLimitProperties.java
@@ -1,0 +1,48 @@
+package org.codeacademy.baltaragisapi.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "app.rate-limit")
+public class RateLimitProperties {
+    
+    /**
+     * Number of requests allowed per time window
+     */
+    private int capacity = 10;
+    
+    /**
+     * Time window duration in minutes
+     */
+    private int windowMinutes = 5;
+    
+    /**
+     * Whether rate limiting is enabled
+     */
+    private boolean enabled = true;
+
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(int capacity) {
+        this.capacity = capacity;
+    }
+
+    public int getWindowMinutes() {
+        return windowMinutes;
+    }
+
+    public void setWindowMinutes(int windowMinutes) {
+        this.windowMinutes = windowMinutes;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/security/SecurityConfig.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.codeacademy.baltaragisapi.security;
 
+import org.codeacademy.baltaragisapi.web.RateLimitFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,8 @@ import java.util.List;
 public class SecurityConfig {
     @Autowired
     private JwtService jwtService;
+    @Autowired
+    private RateLimitFilter rateLimitFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -59,7 +62,8 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .anyRequest().permitAll()
             )
-            .addFilterBefore(new JwtAuthFilter(jwtService), UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(new JwtAuthFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(rateLimitFilter, JwtAuthFilter.class);
         return http.build();
     }
 

--- a/src/main/java/org/codeacademy/baltaragisapi/web/RateLimitFilter.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/web/RateLimitFilter.java
@@ -1,0 +1,135 @@
+package org.codeacademy.baltaragisapi.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Bucket4j;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.codeacademy.baltaragisapi.config.RateLimitProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(RateLimitFilter.class);
+    
+    private final RateLimitProperties rateLimitProperties;
+    private final ObjectMapper objectMapper;
+    private final ConcurrentHashMap<String, Bucket> buckets = new ConcurrentHashMap<>();
+    
+    public RateLimitFilter(RateLimitProperties rateLimitProperties, ObjectMapper objectMapper) {
+        this.rateLimitProperties = rateLimitProperties;
+        this.objectMapper = objectMapper;
+    }
+    
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, 
+                                    @NonNull HttpServletResponse response, 
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        
+        // Only apply rate limiting to specific endpoints
+        if (!shouldRateLimit(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        
+        // Skip if rate limiting is disabled
+        if (!rateLimitProperties.isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        
+        String clientIp = getClientIp(request);
+        Bucket bucket = getBucket(clientIp);
+        
+        if (bucket.tryConsume(1)) {
+            // Request allowed
+            filterChain.doFilter(request, response);
+        } else {
+            // Rate limit exceeded
+            log.warn("Rate limit exceeded for IP: {} on endpoint: {} {}", 
+                    clientIp, request.getMethod(), request.getRequestURI());
+            
+            sendRateLimitExceededResponse(response);
+        }
+    }
+    
+    private boolean shouldRateLimit(HttpServletRequest request) {
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+        
+        // Rate limit POST requests to orders and waitlist endpoints
+        if (!"POST".equals(method)) {
+            return false;
+        }
+        
+        return uri.equals("/api/v1/orders") || 
+               uri.matches("/api/v1/products/[^/]+/waitlist");
+    }
+    
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        
+        String xRealIp = request.getHeader("X-Real-IP");
+        if (xRealIp != null && !xRealIp.isEmpty()) {
+            return xRealIp;
+        }
+        
+        return request.getRemoteAddr();
+    }
+    
+    private Bucket getBucket(String clientIp) {
+        return buckets.computeIfAbsent(clientIp, this::createBucket);
+    }
+    
+    private Bucket createBucket(String clientIp) {
+        Duration windowDuration = Duration.ofMinutes(rateLimitProperties.getWindowMinutes());
+        Bandwidth bandwidth = Bandwidth.classic(rateLimitProperties.getCapacity(), 
+                                               Refill.intervally(rateLimitProperties.getCapacity(), windowDuration));
+        return Bucket4j.builder().addLimit(bandwidth).build();
+    }
+    
+    private void sendRateLimitExceededResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        
+        // Calculate retry after
+        long retryAfterSeconds = Duration.ofMinutes(rateLimitProperties.getWindowMinutes()).toSeconds();
+        response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
+        
+        // Create RFC-7807 problem details
+        ProblemDetails problem = new ProblemDetails(
+                "about:blank",
+                "Too Many Requests",
+                HttpStatus.TOO_MANY_REQUESTS.value(),
+                "Rate limit exceeded. Please try again later.",
+                null,
+                "RATE_LIMIT_EXCEEDED",
+                OffsetDateTime.now().toString(),
+                null
+        );
+        
+        response.getWriter().write(objectMapper.writeValueAsString(problem));
+    }
+    
+    // Inner record for problem details response
+    private record ProblemDetails(String type, String title, int status, String detail, String instance,
+                                  String code, String timestamp, java.util.List<java.util.Map<String, String>> errors) {}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,5 +39,10 @@ spring:
 app:
   payments:
     enabled: true
+  # Rate limiting configuration (more lenient for dev)
+  rate-limit:
+    enabled: true
+    capacity: 10
+    window-minutes: 5
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,5 +43,10 @@ app:
   # Payment configuration
   payments:
     enabled: ${PAYMENTS_ENABLED:false}
+  # Rate limiting configuration (production defaults)
+  rate-limit:
+    enabled: true
+    capacity: 5
+    window-minutes: 5
 
 


### PR DESCRIPTION
Implements IP-keyed rate limiting for POST /api/v1/orders and POST /api/v1/products/{slug}/waitlist to prevent abuse.

## Features
- Bucket4j-based rate limiting (10 requests/5min dev, 5 requests/5min prod)
- IP-keyed buckets with configurable limits via app.rate-limit properties  
- Returns 429 with RFC-7807 error format and Retry-After header
- Logs throttled requests without exposing email addresses
- Only POST endpoints rate limited - GET/other methods unaffected

## Acceptance Criteria ✅
- Normal usage unaffected (✅ tested)
- Bursty calls reliably get 429 with structured JSON and Retry-After header (✅ tested)
- Limits externalized in config with different values for dev vs prod (✅ implemented)
- Manual tests confirm all functionality works as expected