### PR TITLE
API: dynamic sitemap.xml + robots.txt with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A Spring Boot e-commerce API for the Baltaragis art and accessories brand, built
 ```yaml
 # application.yml
 app:
+  base-url: ${BASE_URL:https://www.baltaragis.com}  # For sitemap generation
   media:
     base-path: media
     base-url: http://localhost:8080/media
@@ -119,6 +120,7 @@ app:
 
 # application-dev.yml
 app:
+  base-url: http://localhost:8080  # Development URL for sitemap
   payments:
     enabled: true
   rate-limit:
@@ -147,6 +149,10 @@ jwt:
 - `GET /api/v1/i18n/{locale}` - Get translations for locale
 - `POST /api/v1/orders` - Create new order (rate limited)
 - `POST /api/v1/products/{slug}/waitlist` - Join waitlist (rate limited)
+
+### SEO Endpoints
+- `GET /sitemap.xml` - Dynamic sitemap with all published content
+- `GET /robots.txt` - Search engine crawling directives
 
 ### Payment Endpoints (when enabled)
 - `POST /api/v1/orders/checkout-session` - Create checkout session
@@ -200,6 +206,45 @@ jwt:
 - **Development**: `src/main/resources/dev-migration/`
 - **Production**: `src/main/resources/db/migration/`
 
+## 🔍 SEO & Search Engine Optimization
+
+The API provides dynamic SEO endpoints that automatically include all published content without requiring frontend rebuilds.
+
+### Sitemap.xml
+- **Endpoint**: `GET /sitemap.xml`
+- **Content**: Dynamic XML sitemap including:
+  - Home page (`/`)
+  - Products listing (`/products`)
+  - Individual product pages (`/products/{slug}`)
+  - Published content pages (`/pages/{slug}`)
+- **Features**:
+  - Automatic inclusion of newly published content
+  - `lastmod` timestamps from database
+  - Appropriate `changefreq` and `priority` values
+  - Multilingual support with `hreflang` attributes (EN/LT)
+  - Cache headers (5-minute TTL + ETag)
+
+### Robots.txt
+- **Endpoint**: `GET /robots.txt`
+- **Content**: Search engine crawling directives
+- **Features**:
+  - References sitemap URL
+  - Allows all content crawling
+  - Cache headers (1-hour TTL + ETag)
+
+### Frontend Integration
+The sitemap and robots endpoints are designed to work seamlessly with any frontend:
+```html
+<!-- Reference in HTML head -->
+<link rel="sitemap" type="application/xml" href="/sitemap.xml" />
+```
+
+### Configuration
+```yaml
+app:
+  base-url: https://www.baltaragis.com  # Used for generating absolute URLs
+```
+
 ## 📖 Documentation
 
 - **API Documentation**: [OpenAPI/Swagger UI](http://localhost:8080/swagger-ui.html)
@@ -218,6 +263,7 @@ jwt:
 5. **Seed Data Enhancement** - Comprehensive development data
 6. **Security** - JWT auth and rate limiting
 7. **CI Pipeline** - MySQL testing via Testcontainers
+8. **SEO Optimization** - Dynamic sitemap.xml and robots.txt with caching
 
 ### 🔄 Next Steps
 - **Media Pipeline**: S3/R2 integration for production photo storage

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
             <artifactId>flyway-core</artifactId>
         </dependency>
 
+
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>

--- a/src/main/java/org/codeacademy/baltaragisapi/controller/SitemapController.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/controller/SitemapController.java
@@ -1,0 +1,122 @@
+package org.codeacademy.baltaragisapi.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.codeacademy.baltaragisapi.service.SitemapService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.StringWriter;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "SEO", description = "SEO endpoints for sitemap and robots.txt")
+public class SitemapController {
+    
+    private final SitemapService sitemapService;
+    
+    @GetMapping(value = "/sitemap.xml", produces = MediaType.APPLICATION_XML_VALUE)
+    @Operation(
+        summary = "Get sitemap.xml",
+        description = "Returns the website sitemap in XML format with all published pages and products. " +
+                     "Includes alternate language links for internationalization and cache headers for performance.",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "Sitemap XML returned successfully",
+                content = @Content(
+                    mediaType = MediaType.APPLICATION_XML_VALUE,
+                    schema = @Schema(type = "string", example = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...")
+                )
+            )
+        }
+    )
+    public ResponseEntity<String> getSitemap() {
+        try {
+            log.info("Generating sitemap.xml");
+            
+            String xmlContent = sitemapService.generateSitemapXml();
+            String etag = generateETag(xmlContent);
+            
+            return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(5, TimeUnit.MINUTES).cachePublic())
+                .eTag(etag)
+                .contentType(MediaType.APPLICATION_XML)
+                .body(xmlContent);
+                
+        } catch (Exception e) {
+            log.error("Error generating sitemap.xml", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+    @GetMapping(value = "/robots.txt", produces = MediaType.TEXT_PLAIN_VALUE)
+    @Operation(
+        summary = "Get robots.txt",
+        description = "Returns the robots.txt file with sitemap reference and crawling directives.",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "Robots.txt returned successfully",
+                content = @Content(
+                    mediaType = MediaType.TEXT_PLAIN_VALUE,
+                    schema = @Schema(type = "string", example = "User-agent: *\\nAllow: /\\n\\nSitemap: https://www.baltaragis.com/sitemap.xml")
+                )
+            )
+        }
+    )
+    public ResponseEntity<String> getRobotsTxt() {
+        try {
+            log.info("Generating robots.txt");
+            
+            String robotsContent = sitemapService.generateRobotsTxt();
+            String etag = generateETag(robotsContent);
+            
+            return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic())
+                .eTag(etag)
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(robotsContent);
+                
+        } catch (Exception e) {
+            log.error("Error generating robots.txt", e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+    
+
+    
+    private String generateETag(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] hash = digest.digest(content.getBytes());
+            StringBuilder hexString = new StringBuilder();
+            
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+            
+            return "\"" + hexString.toString() + "\"";
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("MD5 algorithm not available, using hashCode for ETag", e);
+            return "\"" + Math.abs(content.hashCode()) + "\"";
+        }
+    }
+}

--- a/src/main/java/org/codeacademy/baltaragisapi/repository/PageRepository.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/repository/PageRepository.java
@@ -3,11 +3,14 @@ package org.codeacademy.baltaragisapi.repository;
 import org.codeacademy.baltaragisapi.entity.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PageRepository extends JpaRepository<Page, Long> {
     Optional<Page> findBySlugAndIsPublishedTrue(String slug);
     boolean existsBySlug(String slug);
+    
+    List<Page> findByIsPublishedTrue();
 }
 
 

--- a/src/main/java/org/codeacademy/baltaragisapi/repository/ProductRepository.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/repository/ProductRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
@@ -15,6 +16,8 @@ public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpec
     boolean existsBySlug(String slug);
 
     Page<Product> findAllByIsPublishedTrue(Pageable pageable);
+    
+    List<Product> findByIsPublishedTrue();
 }
 
 

--- a/src/main/java/org/codeacademy/baltaragisapi/service/SitemapService.java
+++ b/src/main/java/org/codeacademy/baltaragisapi/service/SitemapService.java
@@ -1,0 +1,127 @@
+package org.codeacademy.baltaragisapi.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.codeacademy.baltaragisapi.entity.Page;
+import org.codeacademy.baltaragisapi.entity.Product;
+import org.codeacademy.baltaragisapi.repository.PageRepository;
+import org.codeacademy.baltaragisapi.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SitemapService {
+    
+    private final ProductRepository productRepository;
+    private final PageRepository pageRepository;
+    
+    @Value("${app.base-url:https://www.baltaragis.com}")
+    private String baseUrl;
+    
+    public String generateSitemapXml() {
+        log.info("Generating sitemap for base URL: {}", baseUrl);
+        
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\">\n");
+        
+        // Add home page
+        addHomePageUrl(xml);
+        
+        // Add products listing page
+        addProductsListingUrl(xml);
+        
+        // Add individual product pages
+        addProductUrls(xml);
+        
+        // Add published pages
+        addPageUrls(xml);
+        
+        xml.append("</urlset>");
+        
+        log.info("Generated sitemap XML with base URL: {}", baseUrl);
+        return xml.toString();
+    }
+    
+    private void addHomePageUrl(StringBuilder xml) {
+        xml.append("  <url>\n");
+        xml.append("    <loc>").append(baseUrl).append("/</loc>\n");
+        xml.append("    <lastmod>").append(OffsetDateTime.now().format(DateTimeFormatter.ISO_INSTANT)).append("</lastmod>\n");
+        xml.append("    <changefreq>daily</changefreq>\n");
+        xml.append("    <priority>1.0</priority>\n");
+        addAlternateLinks(xml, baseUrl + "/", baseUrl + "/?locale=lt");
+        xml.append("  </url>\n");
+    }
+    
+    private void addProductsListingUrl(StringBuilder xml) {
+        xml.append("  <url>\n");
+        xml.append("    <loc>").append(baseUrl).append("/products</loc>\n");
+        xml.append("    <lastmod>").append(getLatestProductUpdateTime().format(DateTimeFormatter.ISO_INSTANT)).append("</lastmod>\n");
+        xml.append("    <changefreq>daily</changefreq>\n");
+        xml.append("    <priority>0.9</priority>\n");
+        addAlternateLinks(xml, baseUrl + "/products", baseUrl + "/products?locale=lt");
+        xml.append("  </url>\n");
+    }
+    
+    private void addProductUrls(StringBuilder xml) {
+        List<Product> publishedProducts = productRepository.findByIsPublishedTrue();
+        
+        for (Product product : publishedProducts) {
+            xml.append("  <url>\n");
+            xml.append("    <loc>").append(baseUrl).append("/products/").append(product.getSlug()).append("</loc>\n");
+            xml.append("    <lastmod>").append(product.getUpdatedAt().format(DateTimeFormatter.ISO_INSTANT)).append("</lastmod>\n");
+            xml.append("    <changefreq>weekly</changefreq>\n");
+            xml.append("    <priority>0.8</priority>\n");
+            addAlternateLinks(xml, 
+                baseUrl + "/products/" + product.getSlug(), 
+                baseUrl + "/products/" + product.getSlug() + "?locale=lt");
+            xml.append("  </url>\n");
+        }
+    }
+    
+    private void addPageUrls(StringBuilder xml) {
+        List<Page> publishedPages = pageRepository.findByIsPublishedTrue();
+        
+        for (Page page : publishedPages) {
+            xml.append("  <url>\n");
+            xml.append("    <loc>").append(baseUrl).append("/pages/").append(page.getSlug()).append("</loc>\n");
+            xml.append("    <lastmod>").append(page.getUpdatedAt().format(DateTimeFormatter.ISO_INSTANT)).append("</lastmod>\n");
+            xml.append("    <changefreq>monthly</changefreq>\n");
+            xml.append("    <priority>0.7</priority>\n");
+            addAlternateLinks(xml, 
+                baseUrl + "/pages/" + page.getSlug(), 
+                baseUrl + "/pages/" + page.getSlug() + "?locale=lt");
+            xml.append("  </url>\n");
+        }
+    }
+    
+    private void addAlternateLinks(StringBuilder xml, String enUrl, String ltUrl) {
+        xml.append("    <xhtml:link rel=\"alternate\" hreflang=\"en\" href=\"").append(enUrl).append("\"/>\n");
+        xml.append("    <xhtml:link rel=\"alternate\" hreflang=\"lt\" href=\"").append(ltUrl).append("\"/>\n");
+    }
+    
+    private OffsetDateTime getLatestProductUpdateTime() {
+        return productRepository.findByIsPublishedTrue()
+            .stream()
+            .map(Product::getUpdatedAt)
+            .max(OffsetDateTime::compareTo)
+            .orElse(OffsetDateTime.now());
+    }
+    
+    public String generateRobotsTxt() {
+        StringBuilder robots = new StringBuilder();
+        robots.append("User-agent: *\n");
+        robots.append("Allow: /\n");
+        robots.append("\n");
+        robots.append("# Sitemap\n");
+        robots.append("Sitemap: ").append(baseUrl).append("/sitemap.xml\n");
+        
+        return robots.toString();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,8 @@ spring:
 
 # Development-specific configuration
 app:
+  # Use localhost for development sitemap
+  base-url: http://localhost:8080
   payments:
     enabled: true
   # Rate limiting configuration (more lenient for dev)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,8 +35,11 @@ springdoc:
   swagger-ui:
     path: /swagger-ui
 
-# Media storage configuration
+# Application configuration
 app:
+  # Base URL for sitemap generation
+  base-url: ${BASE_URL:https://www.baltaragis.com}
+  # Media storage configuration
   media:
     base-path: media
     base-url: http://localhost:8080/media

--- a/src/test/java/org/codeacademy/baltaragisapi/controller/SitemapControllerTest.java
+++ b/src/test/java/org/codeacademy/baltaragisapi/controller/SitemapControllerTest.java
@@ -1,0 +1,112 @@
+package org.codeacademy.baltaragisapi.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class SitemapControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getSitemap_shouldReturnValidXml() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_XML))
+                .andExpect(header().exists("Cache-Control"))
+                .andExpect(header().exists("ETag"))
+                .andExpect(content().string(containsString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")))
+                .andExpect(content().string(containsString("<urlset")))
+                .andExpect(content().string(containsString("xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"")))
+                .andExpect(content().string(containsString("xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"")));
+    }
+
+    @Test
+    void getSitemap_shouldIncludeHomePageUrl() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("<loc>http://localhost:8080/</loc>")))
+                .andExpect(content().string(containsString("<priority>1.0</priority>")))
+                .andExpect(content().string(containsString("<changefreq>daily</changefreq>")));
+    }
+
+    @Test
+    void getSitemap_shouldIncludeProductsListingUrl() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("<loc>http://localhost:8080/products</loc>")))
+                .andExpect(content().string(containsString("<priority>0.9</priority>")))
+                .andExpect(content().string(containsString("<changefreq>daily</changefreq>")));
+    }
+
+    @Test
+    void getSitemap_shouldIncludePublishedProducts() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                // Should include published products from seed data
+                .andExpect(content().string(containsString("/products/")))
+                .andExpect(content().string(containsString("<priority>0.8</priority>")))
+                .andExpect(content().string(containsString("<changefreq>weekly</changefreq>")));
+    }
+
+    @Test
+    void getSitemap_shouldIncludeAlternateLanguageLinks() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("hreflang=\"en\"")))
+                .andExpect(content().string(containsString("hreflang=\"lt\"")))
+                .andExpect(content().string(containsString("rel=\"alternate\"")));
+    }
+
+    @Test
+    void getSitemap_shouldIncludePublishedPages() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                // Should include published pages from seed data
+                .andExpect(content().string(containsString("/pages/")))
+                .andExpect(content().string(containsString("<priority>0.7</priority>")))
+                .andExpect(content().string(containsString("<changefreq>monthly</changefreq>")));
+    }
+
+    @Test
+    void getRobotsTxt_shouldReturnValidRobotsTxt() throws Exception {
+        mockMvc.perform(get("/robots.txt"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.TEXT_PLAIN))
+                .andExpect(header().exists("Cache-Control"))
+                .andExpect(header().exists("ETag"))
+                .andExpect(content().string(containsString("User-agent: *")))
+                .andExpect(content().string(containsString("Allow: /")))
+                .andExpect(content().string(containsString("Sitemap: http://localhost:8080/sitemap.xml")));
+    }
+
+    @Test
+    void getSitemap_shouldHaveCacheHeaders() throws Exception {
+        mockMvc.perform(get("/sitemap.xml"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Cache-Control", containsString("max-age=300")))
+                .andExpect(header().string("Cache-Control", containsString("public")))
+                .andExpect(header().exists("ETag"));
+    }
+
+    @Test
+    void getRobotsTxt_shouldHaveCacheHeaders() throws Exception {
+        mockMvc.perform(get("/robots.txt"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Cache-Control", containsString("max-age=3600")))
+                .andExpect(header().string("Cache-Control", containsString("public")))
+                .andExpect(header().exists("ETag"));
+    }
+}


### PR DESCRIPTION
## Feature: Dynamic Sitemap and Robots.txt API

Implements always-fresh sitemap.xml and robots.txt served from the backend API.

### Changes
- **GET /sitemap.xml**: Dynamic XML sitemap generation
  - Includes all published products and pages  
  - Home page and products listing
  - Automatic lastmod timestamps from database
  - Appropriate changefreq and priority values
  - Multilingual hreflang attributes (EN/LT)
  - 5-minute cache TTL + ETag support

- **GET /robots.txt**: Search engine crawling directives
  - References sitemap URL
  - Allows all content crawling
  - 1-hour cache TTL + ETag support

- **Configuration**: app.base-url property for absolute URLs
- **Documentation**: Updated README with SEO section
- **Testing**: Comprehensive integration tests

### Acceptance Criteria ✅
- [x] /sitemap.xml returns valid XML with current products/pages
- [x] robots.txt is valid and references sitemap URL  
- [x] Unpublished items excluded from sitemap
- [x] New content appears immediately without FE rebuild
- [x] Cache headers implemented for performance
- [x] Hreflang attributes for internationalization

### Technical Details
- Direct XML generation (no JAXB dependencies)
- Repository methods for published content only
- ETag generation using MD5 hashing
- Spring Cache-Control headers
- OpenAPI documentation with Swagger tags

Ready for review and merge when CI passes.